### PR TITLE
remove pacta.portfolio.analysis

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -36,10 +36,6 @@
     "url": "https://github.com/rmi-pacta/pacta.portfolio.audit"
   },
   {
-    "package": "pacta.portfolio.analysis",
-    "url": "https://github.com/rmi-pacta/pacta.portfolio.analysis"
-  },
-  {
     "package": "pacta.portfolio.report",
     "url": "https://github.com/rmi-pacta/pacta.portfolio.report"
   },


### PR DESCRIPTION
pacta.portfolio.analysis has been archived/deprecated (largely replaced by pacta.portfolio.allocate)